### PR TITLE
Only run for production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Minify images with imagemin. This addon is a thin wrapper around [broccoli-image
 
 ## Options
 
+### Broccoli Imagemin options
+
 Define options to be passed directly to `broccoli-imagemin`.
 
     var app = new EmberApp({
@@ -22,3 +24,18 @@ Define options to be passed directly to `broccoli-imagemin`.
     });
 
 Read more about the options you may pass in on the [broccoli-imagemin](https://github.com/Xulai/broccoli-imagemin) page.
+
+### Enabled
+
+Type: `Boolean`  
+Default: `app.env === 'production'`
+
+Enable minification of images. Defaults to `true` in production environment, otherwise `false`.
+
+    var app = new EmberApp({
+      imagemin: {
+        enabled: true
+      }
+    });
+
+Alternatively, you may simply set `{ imagemin: true }` as a shortcut.

--- a/index.js
+++ b/index.js
@@ -9,11 +9,28 @@ function EmberCLIImagemin(project) {
 
 EmberCLIImagemin.prototype.included = function included(app) {
   this.app = app;
-  this.options = this.app.options.imagemin;
+
+  var defaultOptions = {
+    enabled: this.app.env === 'production'
+  };
+
+  if (this.app.options.imagemin === false) {
+    this.options = this.app.options.imagemin = { enabled: false };
+  } else {
+    this.options = this.app.options.imagemin = this.app.options.imagemin || {};
+  }
+
+  for (var option in defaultOptions) {
+    if (!this.options.hasOwnProperty(option)) {
+      this.options[option] = defaultOptions[option];
+    }
+  }
 };
 
 EmberCLIImagemin.prototype.postprocessTree = function postprocessTree(type, tree) {
-  tree = imagemin(tree, this.options);
+  if (this.options.enabled) {
+    tree = imagemin(tree, this.options);
+  }
 
   return tree;
 };


### PR DESCRIPTION
Is there any way to have this run only when `environment = production`? Seems like an unnecessary step for development builds, IMHO.
