### PR TITLE
Use imagemin@5 pluggable configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - 4
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,18 @@ Define options to be passed directly to `broccoli-imagemin`.
 ```js
 var app = new EmberApp({
   imagemin: {
-    interlaced: true,
-    optimizationLevel: 3,
-    progressive: true,
-    lossyPNG: false
+    plugins: [
+      require('imagemin-jpegtran')({ progressive: true }),
+      require('imagemin-optipng')({ optimizationLevel: 3 }),
+      require('imagemin-svgo')()
+    ]
   }
 });
 ```
 
-Read more about the options you may pass in on the [broccoli-imagemin](https://github.com/Xulai/broccoli-imagemin) page.
+Note that with no plugins specified, nothing will be processed, disabling this addon.
+
+Read more about the options you may pass in on the [broccoli--imagemin](https://github.com/kanongil/broccoli-imagemin) page.
 
 ### Enabled
 
@@ -42,17 +45,11 @@ Enable minification of images. Defaults to `true` in production environment, oth
 ```js
 var app = new EmberApp({
   imagemin: {
-    enabled: true
+    enabled: true,
+    plugins: [
+      require('imagemin-jpegtran')(),
+    ]
   }
-});
-```
-
-Alternatively, you may simply set the `imagemin` key to a `Boolean` value as a shortcut to enable/disable. E.g.
-
-```js
-// Enable with default options
-var app = new EmberApp({
-  imagemin: true
 });
 ```
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,7 +6,13 @@ module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
     imagemin: {
-      enabled: true
+      enabled: true,
+      plugins: [
+        require('imagemin-gifsicle')(),
+        require('imagemin-jpegtran')(),
+        require('imagemin-optipng')(),
+        require('imagemin-svgo')()
+      ]
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -9,30 +9,22 @@ module.exports = {
   included: function() {
     this._super.included.apply(this, arguments);
 
-    // Default options
-    var defaultOptions = {
-      enabled: this.app.env === 'production'
-    };
+    this.enabled = this.app.env === 'production'
+    this.options = this.app.options.imagemin = this.app.options.imagemin || {};
 
-    // If the imagemin options key is set to `false` instead of
-    // an options object, disable the addon
-    if (typeof this.app.options.imagemin === 'boolean') {
-      this.options = this.app.options.imagemin = { enabled: this.app.options.imagemin };
-    } else {
-      this.options = this.app.options.imagemin = this.app.options.imagemin || {};
+    if ('enabled' in this.options) {
+      this.enabled = this.options.enabled;
+      delete this.options.enabled;
     }
 
-    // Merge the default options with the passed in options
-    for (var option in defaultOptions) {
-      if (!this.options.hasOwnProperty(option)) {
-        this.options[option] = defaultOptions[option];
-      }
+    if (!this.options.plugins || this.options.plugins.length === 0) {
+      this.enabled = false;
     }
   },
 
   postprocessTree: function(type, tree) {
-    if (this.options.enabled) {
-      tree = imagemin(tree, this.options);
+    if (this.enabled) {
+      tree = new imagemin(tree, this.options);
     }
 
     return tree;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/andybluntish/ember-cli-imagemin/issues"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4.0.0"
   },
   "author": "Andy Stanford-Bluntish <andy@bluntish.net>",
   "license": "MIT",
@@ -43,6 +43,10 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
+    "imagemin-gifsicle": "^5.1.0",
+    "imagemin-jpegtran": "^5.0.2",
+    "imagemin-optipng": "^5.2.1",
+    "imagemin-svgo": "^5.2.0",
     "loader.js": "^4.0.0"
   },
   "keywords": [
@@ -59,7 +63,7 @@
     "svg"
   ],
   "dependencies": {
-    "broccoli-imagemin": "^0.2.1",
+    "broccoli-imagemin": "^1.0.0",
     "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {


### PR DESCRIPTION
This updates the addon to use imagemin v5 pluggable configuration.

This is a major breaking change, requiring changes for every user of this addon. Everyone will need to install, `require`, and instantiate at least one [plugin](https://www.npmjs.com/browse/keyword/imageminplugin), and include it in the `plugins` configuration option.

Note this also updates the engine to `node >= 4`, since the `broccoli-imagemin` dependency now relies on this.