### PR TITLE
Provide a default set of imagemin plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Installation
 
-```js
+```sh
 ember install ember-cli-imagemin
 ```
 
@@ -63,7 +63,7 @@ var app = new EmberApp({
 Type: `Array`  
 Default:
 
-```
+```js
 plugins: [
   require('imagemin-gifsicle')({ interlaced: true }),
   require('imagemin-jpegtran')({ progressive: true }),
@@ -72,6 +72,13 @@ plugins: [
 ]
 ```
 
-Imagemin plugins and options used to compress images.
+Imagemin plugins, and configuration options, used to compress images. Each [imagemin plugin](https://www.npmjs.com/browse/keyword/imageminplugin) needs to be installed into your project via `npm`. Specifying plugins will _replace_ the default list. If you wish to _extend_, the list don't forget to include _all_ plugins you wish to use.
 
-For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
+```js
+var app = new EmberApp({
+  plugins: [
+    require('imagemin-webp')(),
+    require('imagemin-svgo')()
+  ]
+});
+```

--- a/README.md
+++ b/README.md
@@ -17,23 +17,22 @@ ember install ember-cli-imagemin
 
 ### Broccoli Imagemin options
 
-Define options to be passed directly to `broccoli-imagemin`.
+Define options to be passed directly to [broccoli-imagemin](https://github.com/kanongil/broccoli-imagemin).
 
 ```js
 var app = new EmberApp({
   imagemin: {
     plugins: [
+      require('imagemin-gifsicle')({ interlaced: true }),
       require('imagemin-jpegtran')({ progressive: true }),
-      require('imagemin-optipng')({ optimizationLevel: 3 }),
+      require('imagemin-optipng')(),
       require('imagemin-svgo')()
     ]
   }
 });
 ```
 
-Note that with no plugins specified, nothing will be processed, disabling this addon.
-
-Read more about the options you may pass in on the [broccoli--imagemin](https://github.com/kanongil/broccoli-imagemin) page.
+Read more about the options you may pass in on the [broccoli-imagemin](https://github.com/kanongil/broccoli-imagemin) page.
 
 ### Enabled
 
@@ -45,12 +44,25 @@ Enable minification of images. Defaults to `true` in production environment, oth
 ```js
 var app = new EmberApp({
   imagemin: {
-    enabled: true,
-    plugins: [
-      require('imagemin-jpegtran')(),
-    ]
+    enabled: true
   }
 });
 ```
+
+### Plugins
+
+Type: `Array`  
+Default:
+
+```
+plugins: [
+  require('imagemin-gifsicle')({ interlaced: true }),
+  require('imagemin-jpegtran')({ progressive: true }),
+  require('imagemin-optipng')(),
+  require('imagemin-svgo')()
+]
+```
+
+Imagemin plugins and options used to compress images.
 
 For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ var app = new EmberApp({
 });
 ```
 
+Alternatively, you may simply set the `imagemin` key to a `Boolean` value as a shortcut to enable/disable with the default plugins. E.g.
+
+```js
+// Enable with default options
+var app = new EmberApp({
+  imagemin: true
+});
+```
+
 ### Plugins
 
 Type: `Array`  

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,9 +4,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
-    imagemin: {
-      enabled: true
-    }
+    imagemin: true
   });
 
   /*

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,13 +5,7 @@ module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
     imagemin: {
-      enabled: true,
-      plugins: [
-        require('imagemin-gifsicle')(),
-        require('imagemin-jpegtran')(),
-        require('imagemin-optipng')(),
-        require('imagemin-svgo')()
-      ]
+      enabled: true
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,14 @@ module.exports = {
       this.enabled = this.app.env === 'production';
     }
 
-    if (!this.app.options.imagemin.plugins || this.app.options.imagemin.plugins.length === 0) {
-      this.enabled = false;
+    // if addon is enabled but no plugins have been specified, use a default set
+    if (this.enabled && (!this.app.options.imagemin.plugins || this.app.options.imagemin.plugins.length === 0)) {
+      this.app.options.imagemin.plugins = [
+        require('imagemin-gifsicle')({ interlaced: true }),
+        require('imagemin-jpegtran')({ progressive: true }),
+        require('imagemin-optipng')(),
+        require('imagemin-svgo')()
+      ];
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ module.exports = {
     this._super.included.apply(this, arguments);
     this.app.options.imagemin = this.app.options.imagemin || {};
 
-    if ('enabled' in this.app.options.imagemin) {
+    if (typeof this.app.options.imagemin === 'boolean') {
+      this.enabled = this.app.options.imagemin;
+      this.app.options.imagemin = {};
+    } else if ('enabled' in this.app.options.imagemin) {
       this.enabled = this.app.options.imagemin.enabled;
       delete this.app.options.imagemin.enabled;
     } else {

--- a/package.json
+++ b/package.json
@@ -39,10 +39,6 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.13.0",
     "ember-welcome-page": "^3.0.0",
-    "imagemin-gifsicle": "^5.1.0",
-    "imagemin-jpegtran": "^5.0.2",
-    "imagemin-optipng": "^5.2.1",
-    "imagemin-svgo": "^5.2.2",
     "loader.js": "^4.2.3"
   },
   "keywords": [
@@ -60,7 +56,11 @@
   ],
   "dependencies": {
     "broccoli-imagemin": "^1.0.0",
-    "ember-cli-babel": "^6.0.0"
+    "ember-cli-babel": "^6.0.0",
+    "imagemin-gifsicle": "^5.1.0",
+    "imagemin-jpegtran": "^5.0.2",
+    "imagemin-optipng": "^5.2.1",
+    "imagemin-svgo": "^5.2.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Provide a set of imagemin plugins (and options) to use by default when the application has not specified any.

The aim is to make the addon as simple to use as possible—most users should just need to `ember install ember-cli-imagemin` and not need to worry about adding plugins themselves. This also reinstates the same behaviour as the current version of the addon, making upgrading more straightforward.

Applications that require further customisation can still do so by installing and requiring plugins, and manually passing them in the options. 