### PR TITLE
updated imagemin-svgo to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",
-    "imagemin-svgo": "^5.2.2"
+    "imagemin-svgo": "^6.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
there is a bug in imagemin-svgo 5 that is causing our svgs to become empty files, it has been fixed with the latest version. This might be a breaking change, update your version accordingly 